### PR TITLE
Load bottleneck fixes

### DIFF
--- a/gatling-tests/pom.xml
+++ b/gatling-tests/pom.xml
@@ -41,7 +41,7 @@
         <artifactId>gatling-maven-plugin</artifactId>
         <version>${gatling-maven-plugin.version}</version>
         <configuration>
-          <simulationClass>es.uniovi.arquisoft.wichat.loadtests.Register</simulationClass>
+          <simulationClass>es.uniovi.arquisoft.wichat.loadtests.PlaySolo</simulationClass>
         </configuration>
       </plugin>
       <plugin>

--- a/gatling-tests/pom.xml
+++ b/gatling-tests/pom.xml
@@ -41,7 +41,7 @@
         <artifactId>gatling-maven-plugin</artifactId>
         <version>${gatling-maven-plugin.version}</version>
         <configuration>
-          <simulationClass>es.uniovi.arquisoft.wichat.loadtests.PlaySolo</simulationClass>
+          <simulationClass>es.uniovi.arquisoft.wichat.loadtests.Register</simulationClass>
         </configuration>
       </plugin>
       <plugin>

--- a/gatling-tests/src/test/scala/es/uniovi/arquisoft/wichat/loadtests/PlaySolo.scala
+++ b/gatling-tests/src/test/scala/es/uniovi/arquisoft/wichat/loadtests/PlaySolo.scala
@@ -205,5 +205,5 @@ class PlaySolo extends Simulation {
         )
     )
 
-	setUp(scn.inject(constantUsersPerSec(5).during(15))).protocols(httpProtocol)
+	setUp(scn.inject(constantUsersPerSec(10).during(75))).protocols(httpProtocol)
 }

--- a/gatling-tests/src/test/scala/es/uniovi/arquisoft/wichat/loadtests/PlayVSAI.scala
+++ b/gatling-tests/src/test/scala/es/uniovi/arquisoft/wichat/loadtests/PlayVSAI.scala
@@ -214,5 +214,5 @@ class PlayVSAI extends Simulation {
         )
     )
 
-	setUp(scn.inject(atOnceUsers(1))).protocols(httpProtocol)
+	setUp(scn.inject(constantUsersPerSec(5).during(15))).protocols(httpProtocol)
 }

--- a/webapp/e2e/steps/game.steps.js
+++ b/webapp/e2e/steps/game.steps.js
@@ -11,7 +11,7 @@ let browser;
 defineFeature(feature, test => {
     beforeAll(async () => {
         browser = process.env.GITHUB_ACTIONS
-            ? await puppeteer.launch({ headless: "new", args: ['--no-sandbox', '--disable-setuid-sandbox'], slowMo: 50})
+            ? await puppeteer.launch({ headless: "new", args: ['--no-sandbox', '--disable-setuid-sandbox'], slowMo: 40})
             : await puppeteer.launch({ headless: false, slowMo: 50});
 
         page = await browser.newPage();

--- a/wikiquestionservice/wikiQuestion-service.js
+++ b/wikiquestionservice/wikiQuestion-service.js
@@ -7,32 +7,27 @@ const Question = require("./question-model");
 const app = express();
 const port = 8004;
 
-const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/questiondb';
-async function connectDB() {
-  if (mongoose.connection.readyState === 0) {
-    await mongoose.connect(mongoUri);
-  }
-}
-
-async function disconnectDB() {
-  if (mongoose.connection.readyState !== 0) {
-    await mongoose.disconnect();
-  }
-}
-
+const mongoUri = process.env.MONGODB_URI;
+mongoose.connect(mongoUri);
 
 const questionManager = new QuestionManager();
 
 const defaultTopics = ["all"];
 const defaultNumQuestions = 25;
 
-
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
 function filterValidTopics(rawTopic) {
-  const validCategories = ["paises", "cine", "clubes", "literatura", "arte", "all"];
-  return rawTopic.split(",").filter(t => validCategories.includes(t));
+  const validCategories = [
+    "paises",
+    "cine",
+    "clubes",
+    "literatura",
+    "arte",
+    "all",
+  ];
+  return rawTopic.split(",").filter((t) => validCategories.includes(t));
 }
 
 app.get("/questions", async (req, res) => {
@@ -46,7 +41,9 @@ app.get("/questions", async (req, res) => {
   let topics = filterValidTopics(topic);
 
   if (topics.length === 0) {
-    return res.status(400).json({ error: "No se proporcionaron categorías válidas." });
+    return res
+      .status(400)
+      .json({ error: "No se proporcionaron categorías válidas." });
   }
 
   try {
@@ -54,7 +51,10 @@ app.get("/questions", async (req, res) => {
       topics = ["all"];
     }
 
-      const selectedQuestions = await questionManager.loadAllQuestions(topics, numQuestions);
+    const selectedQuestions = await questionManager.loadAllQuestions(
+      topics,
+      numQuestions
+    );
 
     const formattedQuestions = selectedQuestions.map((q) => ({
       pregunta: q.obtenerPreguntaPorIdioma(),
@@ -71,9 +71,11 @@ app.get("/questions", async (req, res) => {
 });
 
 app.get("/questionsDB", async (req, res) => {
-  await connectDB();
   const numQuestions = parseInt(req.query.n ?? defaultNumQuestions, 10);
-  const topic = (req.query.topic && req.query.topic !== "undefined") ? req.query.topic : defaultTopics;
+  const topic =
+    req.query.topic && req.query.topic !== "undefined"
+      ? req.query.topic
+      : defaultTopics;
 
   if (numQuestions > 30) {
     return res.status(400).json({ error: "El límite de preguntas es 30" });
@@ -82,11 +84,13 @@ app.get("/questionsDB", async (req, res) => {
   let topics = filterValidTopics(topic);
 
   if (topics.length === 0) {
-    return res.status(400).json({ error: "No se proporcionaron categorías válidas." });
+    return res
+      .status(400)
+      .json({ error: "No se proporcionaron categorías válidas." });
   }
 
   try {
-    if (topics.includes("all")|| topics.length === 0) {
+    if (topics.includes("all") || topics.length === 0) {
       topics = ["paises", "cine", "clubes", "literatura", "arte"];
     }
 
@@ -101,28 +105,31 @@ app.get("/questionsDB", async (req, res) => {
 
       // Obtener preguntas de la categoría actual
       const categoryQuestions = await Question.aggregate([
-        { $match: { category: topic, _id: { $nin: Array.from(selectedQuestionIds) } } },
-        { $sample: { size: numToFetch } }
+        {
+          $match: {
+            category: topic,
+            _id: { $nin: Array.from(selectedQuestionIds) },
+          },
+        },
+        { $sample: { size: numToFetch } },
       ]);
 
       // Agregar preguntas seleccionadas y registrar sus IDs
       selectedQuestions.push(...categoryQuestions);
-      categoryQuestions.forEach(q => selectedQuestionIds.add(q._id));
+      categoryQuestions.forEach((q) => selectedQuestionIds.add(q._id));
     }
 
-    const formattedQuestions = selectedQuestions.map(q => ({
+    const formattedQuestions = selectedQuestions.map((q) => ({
       pregunta: q.question,
       respuestaCorrecta: q.correctAnswer,
       respuestas: q.incorrectAnswers,
       descripcion: q.description,
-      img: q.img
+      img: q.img,
     }));
 
     res.json(formattedQuestions);
   } catch (error) {
     res.status(500).json({ error: error.message });
-  } finally {
-    await disconnectDB();
   }
 });
 
@@ -135,7 +142,7 @@ async function saveQuestionsToDB(questions) {
         correctAnswer: q.respuestaCorrecta,
         incorrectAnswers: q.respuestasIncorrectas,
         description: q.descripcion,
-        img: q.img
+        img: q.img,
       });
 
       await newQuestion.save();
@@ -148,75 +155,91 @@ async function saveQuestionsToDB(questions) {
 
 async function obtainQuestions() {
   try {
-    await connectDB();
     const categorias = ["paises", "cine", "clubes", "literatura", "arte"];
     for (const categoria of categorias) {
       const count = await Question.countDocuments({ category: categoria });
       if (count < 60) {
         const missingQuestionsCount = 60 - count;
-        const additionalQuestions = await questionManager.loadAllQuestions([categoria], missingQuestionsCount);
+        const additionalQuestions = await questionManager.loadAllQuestions(
+          [categoria],
+          missingQuestionsCount
+        );
         if (additionalQuestions && additionalQuestions.length > 0) {
           await saveQuestionsToDB(additionalQuestions);
         }
-      }else {
+      } else {
         console.log("Suficientes preguntas en la categoría: ", categoria);
-        const allGeneratedQuestions  = await questionManager.loadAllQuestions([categoria], 10);
-        const newQuestions = await filtrarPreguntasNoExistentes(allGeneratedQuestions);
-        const questionsToDelete = await Question.find({ category: categoria }).limit(newQuestions.length);
-        const questionIdsToDelete = questionsToDelete.map(q => q._id);
+        const allGeneratedQuestions = await questionManager.loadAllQuestions(
+          [categoria],
+          10
+        );
+        const newQuestions = await filtrarPreguntasNoExistentes(
+          allGeneratedQuestions
+        );
+        const questionsToDelete = await Question.find({
+          category: categoria,
+        }).limit(newQuestions.length);
+        const questionIdsToDelete = questionsToDelete.map((q) => q._id);
         await Question.deleteMany({ _id: { $in: questionIdsToDelete } });
         if (newQuestions && newQuestions.length > 0) {
           await saveQuestionsToDB(newQuestions);
         }
       }
     }
-    await disconnectDB();
   } catch (error) {
     console.error("❌ Error al obtener el conteo de preguntas:", error);
   }
 }
 
 async function filtrarPreguntasNoExistentes(newQuestions) {
-  const nuevosEnunciados = newQuestions.map(q => q.preguntas.es);
+  const nuevosEnunciados = newQuestions.map((q) => q.preguntas.es);
 
-  const existentes = await Question.find({ 'question.es': { $in: nuevosEnunciados } }, 'question.es').lean();
+  const existentes = await Question.find(
+    { "question.es": { $in: nuevosEnunciados } },
+    "question.es"
+  ).lean();
 
-  const enunciadosExistentes = new Set(existentes.map(q => q.question.es));
+  const enunciadosExistentes = new Set(existentes.map((q) => q.question.es));
 
-  return newQuestions.filter(q => !enunciadosExistentes.has(q.preguntas.es));
+  return newQuestions.filter((q) => !enunciadosExistentes.has(q.preguntas.es));
 }
-
 
 if (process.env.NODE_ENV === "e2e_test") {
   app.get("/generateQuestionsIfNotExists", async (req, res) => {
     console.log("Creando preguntas en ejecución de test.");
     try {
-      await connectDB();
-      const selectedQuestions = await questionManager.loadAllQuestions(["all"], 30);
+      const selectedQuestions = await questionManager.loadAllQuestions(
+        ["all"],
+        30
+      );
       await saveQuestionsToDB(selectedQuestions);
       res.json(selectedQuestions);
-    }
-    catch (error) {
+    } catch (error) {
       res.status(500).json({ error: error.message });
     }
   });
 }
 
+var server = null;
+
 if (require.main === module) {
-  app.listen(port, () => {
+  server = app.listen(port, () => {
     console.log(`🚀 Question Service listening at http://localhost:${port}`);
     obtainQuestions().catch((err) =>
-        console.error("❌ Error al obtener preguntas:", err)
+      console.error("❌ Error al obtener preguntas:", err)
     );
   });
 }
 
 if (process.env.NODE_ENV === "e2e_test") {
-  app.listen(port, () => {
+  server = app.listen(port, () => {
     console.log("No se han cargado preguntas, ejecución en tests.");
     console.log(`🚀 Question Service listening at http://localhost:${port}`);
   });
 }
 
+server.on("close", () => {
+  mongoose.connection.close();
+});
 
 module.exports = app;

--- a/wikiquestionservice/wikiQuestion-service.test.js
+++ b/wikiquestionservice/wikiQuestion-service.test.js
@@ -1,325 +1,405 @@
+
+jest.mock('mongoose');
 const request = require("supertest");
+process.env.NODE_ENV = 'test';
 const server = require("./wikiQuestion-service");
 const Question = require("./questiongenerator/question");
-const WikidataQueryService = require('./questiongenerator/questionGen');
-
+const WikidataQueryService = require("./questiongenerator/questionGen");
 const CategoryLoader = require("./questiongenerator/categoryLoader");
 
 /* TEST FUNCIONANDO cambio */
-describe('Wikidata Service', () => {
+describe("Wikidata Service", () => {
+  describe("Category Loader Tests", () => {
+    /* Test para comprobar que poniendo "all" nos cargan todas las categorías */
+    it('should distribute questions across all valid categories when "all" is selected', () => {
+      const loader = new CategoryLoader(["all"], 30);
+      const services = loader.getAllServices();
 
-
-    describe('Category Loader Tests', () => {
-        /* Test para comprobar que poniendo "all" nos cargan todas las categorías */
-        it('should distribute questions across all valid categories when "all" is selected', () => {
-            const loader = new CategoryLoader(["all"], 30);
-            const services = loader.getAllServices();
-
-            expect(services).toHaveProperty('cine');
-            expect(services).toHaveProperty('literatura');
-            expect(services).toHaveProperty('paises');
-            expect(services).toHaveProperty('clubes');
-            expect(services).toHaveProperty('arte');
-            expect(Object.keys(services).length).toBe(5);  // Solo categorías válidas deben estar
-        });
-
-        /* Test para comprobar que poniendo "all" y otra nos cargan todas las categorías igualmente */
-        it('should include "all" categories and the specified category when "all" is combined with another category', () => {
-            const loader = new CategoryLoader(["all", "cine"], 30);
-            const services = loader.getAllServices();
-
-            expect(services).toHaveProperty('cine');
-            expect(services).toHaveProperty('literatura');
-            expect(services).toHaveProperty('paises');
-            expect(services).toHaveProperty('clubes');
-            expect(services).toHaveProperty('arte');
-            expect(Object.keys(services).length).toBe(5); // Debería incluir todas las categorías
-        });
-
-        /* Test para comprobar que solo se cargan las categorías seleccionadas */
-        it('should load questions only from the "cine" category', () => {
-            const loader = new CategoryLoader(["cine"], 10);
-            const services = loader.getAllServices();
-
-            expect(services).toHaveProperty('cine');
-            expect(services).not.toHaveProperty('literatura');
-            expect(services).not.toHaveProperty('paises');
-            expect(services).not.toHaveProperty('clubes');
-            expect(services).not.toHaveProperty('arte');
-        });
-
-        it('should load questions only from the "literatura" category', () => {
-            const loader = new CategoryLoader(["literatura"], 10);
-            const services = loader.getAllServices();
-
-            expect(services).toHaveProperty('literatura');
-            expect(services).not.toHaveProperty('cine');
-            expect(services).not.toHaveProperty('paises');
-            expect(services).not.toHaveProperty('clubes');
-            expect(services).not.toHaveProperty('arte');
-        });
-
-        it('should load questions only from the "paises" category', () => {
-            const loader = new CategoryLoader(["paises"], 10);
-            const services = loader.getAllServices();
-
-            expect(services).toHaveProperty('paises');
-            expect(services).not.toHaveProperty('cine');
-            expect(services).not.toHaveProperty('literatura');
-            expect(services).not.toHaveProperty('clubes');
-            expect(services).not.toHaveProperty('arte');
-        });
-
-        it('should load questions only from the "clubes" category', () => {
-            const loader = new CategoryLoader(["clubes"], 10);
-            const services = loader.getAllServices();
-
-            expect(services).toHaveProperty('clubes');
-            expect(services).not.toHaveProperty('cine');
-            expect(services).not.toHaveProperty('literatura');
-            expect(services).not.toHaveProperty('paises');
-            expect(services).not.toHaveProperty('arte');
-        });
-
-        it('should load questions only from the "arte" category', () => {
-            const loader = new CategoryLoader(["arte"], 10);
-            const services = loader.getAllServices();
-
-            expect(services).toHaveProperty('arte');
-            expect(services).not.toHaveProperty('cine');
-            expect(services).not.toHaveProperty('literatura');
-            expect(services).not.toHaveProperty('paises');
-            expect(services).not.toHaveProperty('clubes');
-        });
-
-        /* Test para comprobar que solo se cargan las categorías seleccionadas */
-        it('should load questions from "paises" and "clubes" categories only', () => {
-            const loader = new CategoryLoader(["paises", "clubes"], 10);
-            const services = loader.getAllServices();
-
-            expect(services).toHaveProperty('paises');
-            expect(services).toHaveProperty('clubes');
-            expect(services).not.toHaveProperty('cine');
-            expect(services).not.toHaveProperty('literatura');
-            expect(services).not.toHaveProperty('arte');
-        });
-
-        it('should load questions from "literatura" and "arte" categories only', () => {
-            const loader = new CategoryLoader(["literatura", "arte", "cine"], 10);
-            const services = loader.getAllServices();
-
-            expect(services).toHaveProperty('literatura');
-            expect(services).toHaveProperty('arte');
-            expect(services).not.toHaveProperty('paises');
-            expect(services).not.toHaveProperty('clubes');
-        });
-
-        /* Test para comprobar que con temas inválidos no se carga ninguna categoría */
-        it('should not load any questions for an invalid category', () => {
-            const loader = new CategoryLoader(["invalido"], 10);
-            const services = loader.getAllServices();
-
-            expect(Object.keys(services)).toHaveLength(0);
-        });
-
-        it('should include all valid categories when "all" is selected with an invalid category', () => {
-            const loader = new CategoryLoader(["all", "invalido"], 10);
-            const services = loader.getAllServices();
-
-            expect(services).toHaveProperty('cine');
-            expect(services).toHaveProperty('literatura');
-            expect(services).toHaveProperty('paises');
-            expect(services).toHaveProperty('clubes');
-            expect(services).toHaveProperty('arte');
-            expect(Object.keys(services).length).toBe(5);
-        });
-
-        it('should include clubes when "clubes" is selected with an invalid category', () => {
-            const loader = new CategoryLoader(["clubes", "invalido"], 10);
-            const services = loader.getAllServices();
-
-            expect(services).not.toHaveProperty('cine');
-            expect(services).not.toHaveProperty('literatura');
-            expect(services).not.toHaveProperty('paises');
-            expect(services).toHaveProperty('clubes');
-            expect(services).not.toHaveProperty('arte');
-            expect(Object.keys(services).length).toBe(1);
-        });
+      expect(services).toHaveProperty("cine");
+      expect(services).toHaveProperty("literatura");
+      expect(services).toHaveProperty("paises");
+      expect(services).toHaveProperty("clubes");
+      expect(services).toHaveProperty("arte");
+      expect(Object.keys(services).length).toBe(5); // Solo categorías válidas deben estar
     });
 
-    describe('API Tests', () => {
-        it("should return 400 if the number of questions is more than 30", async () => {
-            const response = await request(server).get("/questions?n=31");
-            expect(response.status).toBe(400);
-            expect(response.body.error).toBe("El límite de preguntas es 30");
-        });
+    /* Test para comprobar que poniendo "all" y otra nos cargan todas las categorías igualmente */
+    it('should include "all" categories and the specified category when "all" is combined with another category', () => {
+      const loader = new CategoryLoader(["all", "cine"], 30);
+      const services = loader.getAllServices();
 
-        it("should return 400 if no valid categories are provided", async () => {
-            const response = await request(server).get("/questions?topic=invalidCategory");
-            expect(response.status).toBe(400);
-            expect(response.body.error).toBe("No se proporcionaron categorías válidas.");
-        });
-
-        it("should return questions for valid categories", async () => {
-            const response = await request(server).get("/questions?topic=paises,cine&n=5");
-            expect(response.status).toBe(200);
-            expect(response.body).toBeInstanceOf(Array);
-        }, 30000);
-
-        it("should return the exact number of questions when requesting fewer questions than available", async () => {
-            const response = await request(server).get("/questions?topic=all&n=5");
-            expect(response.status).toBe(200);
-            expect(response.body.length).toBe(5);
-        }, 30000);
-
-        it("should return questions for specific categories (e.g., 'paises' and 'cine')", async () => {
-            const response = await request(server).get("/questions?topic=paises,cine&n=5");
-            expect(response.status).toBe(200);
-            expect(response.body).toBeInstanceOf(Array);
-            expect(response.body.length).toBe(5);
-            response.body.forEach(question => {
-                expect(question).toHaveProperty('pregunta');
-                expect(question).toHaveProperty('respuestaCorrecta');
-                expect(question).toHaveProperty('respuestas');
-            });
-        }, 30000);
+      expect(services).toHaveProperty("cine");
+      expect(services).toHaveProperty("literatura");
+      expect(services).toHaveProperty("paises");
+      expect(services).toHaveProperty("clubes");
+      expect(services).toHaveProperty("arte");
+      expect(Object.keys(services).length).toBe(5); // Debería incluir todas las categorías
     });
 
-    describe('Class Question', () => {
+    /* Test para comprobar que solo se cargan las categorías seleccionadas */
+    it('should load questions only from the "cine" category', () => {
+      const loader = new CategoryLoader(["cine"], 10);
+      const services = loader.getAllServices();
 
-        it('should create a Question instance with correct properties', () => {
-            const respuestaCorrecta = { es: 'Respuesta correcta' };
-            const preguntas = { es: '¿Cuál es la capital de Francia?' };
-            const respuestasIncorrectas = { es: ['Madrid', 'Roma', 'Londres'] };
-            const descripcion = [{ propiedad: 'Capital', valor: 'París' }];
-            const img = ['img1.jpg'];
-
-            const question = new Question(respuestaCorrecta, preguntas, respuestasIncorrectas, descripcion, img);
-
-            expect(question.respuestaCorrecta).toEqual(respuestaCorrecta);
-            expect(question.preguntas).toEqual(preguntas);
-            expect(question.respuestasIncorrectas).toEqual(respuestasIncorrectas);
-            expect(question.descripcion).toEqual(descripcion);
-            expect(question.img).toEqual(img);
-        });
-
-        it('should return correct question for the specified language', () => {
-            const respuestaCorrecta = { es: 'Respuesta correcta' };
-            const preguntas = { es: '¿Cuál es la capital de Francia?' };
-            const respuestasIncorrectas = { es: ['Madrid', 'Roma', 'Londres'] };
-            const descripcion = [{ propiedad: 'Capital', valor: 'París' }];
-            const img = ['img1.jpg'];
-
-            const question = new Question(respuestaCorrecta, preguntas, respuestasIncorrectas, descripcion, img);
-            const questionText = question.obtenerPreguntaPorIdioma();
-
-            expect(questionText['es']).toBe('¿Cuál es la capital de Francia?');
-        });
-
-        it('should return answers in random order', () => {
-            const respuestaCorrecta     = { es: 'Respuesta correcta' };
-            const preguntas             = { es: '¿Cuál es la capital de Francia?' };
-            const respuestasIncorrectas = { es: ['Madrid', 'Roma', 'Londres'] };
-            const descripcion           = [{ propiedad: 'Capital', valor: 'París' }];
-            const img                   = ['img1.jpg'];
-
-            const question  = new Question(respuestaCorrecta, preguntas, respuestasIncorrectas, descripcion, img);
-            const respuestas = question.obtenerRespuestas()['es'];
-            const original   = ['Respuesta correcta', 'Madrid', 'Roma', 'Londres'];
-
-            const cmp = (a, b) => a.localeCompare(b, 'es', { sensitivity: 'variant' });
-            expect(respuestas.sort(cmp)).toEqual(original.sort(cmp));
-        });
-
-        it('should return the image associated with the question', () => {
-            const respuestaCorrecta = { es: 'Respuesta correcta' };
-            const preguntas = { es: '¿Cuál es la capital de Francia?' };
-            const respuestasIncorrectas = { es: ['Madrid', 'Roma', 'Londres'] };
-            const descripcion = [{ propiedad: 'Capital', valor: 'París' }];
-            const img = ['img1.jpg'];
-
-            const question = new Question(respuestaCorrecta, preguntas, respuestasIncorrectas, descripcion, img);
-
-            const imgResult = question.obtenerImg();
-            expect(imgResult).toEqual(img);
-        });
-
-        it('should return the question details as a string', () => {
-            const respuestaCorrecta = { es: 'Respuesta correcta' };
-            const preguntas = { es: '¿Cuál es la capital de Francia?' };
-            const respuestasIncorrectas = { es: ['Madrid', 'Roma', 'Londres'] };
-            const descripcion = [{ propiedad: 'Capital', valor: 'París' }];
-            const img = ['img1.jpg'];
-
-            const question = new Question(respuestaCorrecta, preguntas, respuestasIncorrectas, descripcion, img);
-            const questionString = question.toString();
-
-            expect(questionString).toContain('🌍 **Idioma:** ES');
-            expect(questionString).toContain('❓ Pregunta: ¿Cuál es la capital de Francia?');
-            expect(questionString).toContain('✅ Respuesta correcta: Respuesta correcta');
-            expect(questionString).toContain('❌ Respuestas incorrectas: Madrid, Roma, Londres');
-            expect(questionString).toContain('📝 **Descripción:** Capital: París');
-            expect(questionString).toContain('📸 **Imagen:** img1.jpg');
-        });
-
-        it('should handle empty descriptions and images', () => {
-            const respuestaCorrecta = { es: 'Respuesta correcta' };
-            const preguntas = { es: '¿Cuál es la capital de Francia?' };
-            const respuestasIncorrectas = { es: ['Madrid', 'Roma', 'Londres'] };
-            const descripcion = [];
-            const img = [];
-
-            const question = new Question(respuestaCorrecta, preguntas, respuestasIncorrectas, descripcion, img);
-            const questionString = question.toString();
-
-            expect(questionString).toContain('📝 **Descripción:** No hay descripción disponible.');
-            expect(questionString).toContain('📸 **Imagen:** No hay imagen disponible.');
-        });
-
-        it('should handle missing languages gracefully', () => {
-            const respuestaCorrecta = { es: 'Respuesta correcta' };
-            const preguntas = { es: '¿Cuál es la capital de Francia?' };
-            const respuestasIncorrectas = { es: ['Madrid', 'Roma', 'Londres'] };
-            const descripcion = [{ propiedad: 'Capital', valor: 'París' }];
-            const img = ['img1.jpg'];
-
-            const question = new Question(respuestaCorrecta, preguntas, respuestasIncorrectas, descripcion, img);
-
-            const questionTextInEnglish = question.obtenerPreguntaPorIdioma()['en'];
-            expect(questionTextInEnglish).toBeUndefined();
-        });
-
-        it('should handle multiple languages correctly', () => {
-            const respuestaCorrecta = { es: 'Respuesta correcta', en: 'Correct answer' };
-            const preguntas = { es: '¿Cuál es la capital de Francia?', en: 'What is the capital of France?' };
-            const respuestasIncorrectas = { es: ['Madrid', 'Roma', 'Londres'], en: ['Madrid', 'Rome', 'London'] };
-            const descripcion = [{ propiedad: 'Capital', valor: 'París' }];
-            const img = ['img1.jpg'];
-
-            const question = new Question(respuestaCorrecta, preguntas, respuestasIncorrectas, descripcion, img);
-
-            const questionTextEs = question.obtenerPreguntaPorIdioma()['es'];
-            const questionTextEn = question.obtenerPreguntaPorIdioma()['en'];
-
-            expect(questionTextEs).toBe('¿Cuál es la capital de Francia?');
-            expect(questionTextEn).toBe('What is the capital of France?');
-        });
-
-        it('should handle empty question and answer arrays', () => {
-            const respuestaCorrecta = { es: '', en: '' };
-            const preguntas = { es: '', en: '' };
-            const respuestasIncorrectas = { es: [], en: [] };
-            const descripcion = [];
-            const img = [];
-
-            const question = new Question(respuestaCorrecta, preguntas, respuestasIncorrectas, descripcion, img);
-
-            const questionTextEs = question.obtenerPreguntaPorIdioma()['es'];
-            const questionTextEn = question.obtenerPreguntaPorIdioma()['en'];
-
-            expect(questionTextEs).toBe('');
-            expect(questionTextEn).toBe('');
-        });
+      expect(services).toHaveProperty("cine");
+      expect(services).not.toHaveProperty("literatura");
+      expect(services).not.toHaveProperty("paises");
+      expect(services).not.toHaveProperty("clubes");
+      expect(services).not.toHaveProperty("arte");
     });
 
+    it('should load questions only from the "literatura" category', () => {
+      const loader = new CategoryLoader(["literatura"], 10);
+      const services = loader.getAllServices();
+
+      expect(services).toHaveProperty("literatura");
+      expect(services).not.toHaveProperty("cine");
+      expect(services).not.toHaveProperty("paises");
+      expect(services).not.toHaveProperty("clubes");
+      expect(services).not.toHaveProperty("arte");
+    });
+
+    it('should load questions only from the "paises" category', () => {
+      const loader = new CategoryLoader(["paises"], 10);
+      const services = loader.getAllServices();
+
+      expect(services).toHaveProperty("paises");
+      expect(services).not.toHaveProperty("cine");
+      expect(services).not.toHaveProperty("literatura");
+      expect(services).not.toHaveProperty("clubes");
+      expect(services).not.toHaveProperty("arte");
+    });
+
+    it('should load questions only from the "clubes" category', () => {
+      const loader = new CategoryLoader(["clubes"], 10);
+      const services = loader.getAllServices();
+
+      expect(services).toHaveProperty("clubes");
+      expect(services).not.toHaveProperty("cine");
+      expect(services).not.toHaveProperty("literatura");
+      expect(services).not.toHaveProperty("paises");
+      expect(services).not.toHaveProperty("arte");
+    });
+
+    it('should load questions only from the "arte" category', () => {
+      const loader = new CategoryLoader(["arte"], 10);
+      const services = loader.getAllServices();
+
+      expect(services).toHaveProperty("arte");
+      expect(services).not.toHaveProperty("cine");
+      expect(services).not.toHaveProperty("literatura");
+      expect(services).not.toHaveProperty("paises");
+      expect(services).not.toHaveProperty("clubes");
+    });
+
+    /* Test para comprobar que solo se cargan las categorías seleccionadas */
+    it('should load questions from "paises" and "clubes" categories only', () => {
+      const loader = new CategoryLoader(["paises", "clubes"], 10);
+      const services = loader.getAllServices();
+
+      expect(services).toHaveProperty("paises");
+      expect(services).toHaveProperty("clubes");
+      expect(services).not.toHaveProperty("cine");
+      expect(services).not.toHaveProperty("literatura");
+      expect(services).not.toHaveProperty("arte");
+    });
+
+    it('should load questions from "literatura" and "arte" categories only', () => {
+      const loader = new CategoryLoader(["literatura", "arte", "cine"], 10);
+      const services = loader.getAllServices();
+
+      expect(services).toHaveProperty("literatura");
+      expect(services).toHaveProperty("arte");
+      expect(services).not.toHaveProperty("paises");
+      expect(services).not.toHaveProperty("clubes");
+    });
+
+    /* Test para comprobar que con temas inválidos no se carga ninguna categoría */
+    it("should not load any questions for an invalid category", () => {
+      const loader = new CategoryLoader(["invalido"], 10);
+      const services = loader.getAllServices();
+
+      expect(Object.keys(services)).toHaveLength(0);
+    });
+
+    it('should include all valid categories when "all" is selected with an invalid category', () => {
+      const loader = new CategoryLoader(["all", "invalido"], 10);
+      const services = loader.getAllServices();
+
+      expect(services).toHaveProperty("cine");
+      expect(services).toHaveProperty("literatura");
+      expect(services).toHaveProperty("paises");
+      expect(services).toHaveProperty("clubes");
+      expect(services).toHaveProperty("arte");
+      expect(Object.keys(services).length).toBe(5);
+    });
+
+    it('should include clubes when "clubes" is selected with an invalid category', () => {
+      const loader = new CategoryLoader(["clubes", "invalido"], 10);
+      const services = loader.getAllServices();
+
+      expect(services).not.toHaveProperty("cine");
+      expect(services).not.toHaveProperty("literatura");
+      expect(services).not.toHaveProperty("paises");
+      expect(services).toHaveProperty("clubes");
+      expect(services).not.toHaveProperty("arte");
+      expect(Object.keys(services).length).toBe(1);
+    });
+  });
+
+  describe("API Tests", () => {
+    it("should return 400 if the number of questions is more than 30", async () => {
+      const response = await request(server).get("/questions?n=31");
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe("El límite de preguntas es 30");
+    });
+
+    it("should return 400 if no valid categories are provided", async () => {
+      const response = await request(server).get(
+        "/questions?topic=invalidCategory"
+      );
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe(
+        "No se proporcionaron categorías válidas."
+      );
+    });
+
+    it("should return questions for valid categories", async () => {
+      const response = await request(server).get(
+        "/questions?topic=paises,cine&n=5"
+      );
+      expect(response.status).toBe(200);
+      expect(response.body).toBeInstanceOf(Array);
+    }, 30000);
+
+    it("should return the exact number of questions when requesting fewer questions than available", async () => {
+      const response = await request(server).get("/questions?topic=all&n=5");
+      expect(response.status).toBe(200);
+      expect(response.body.length).toBe(5);
+    }, 30000);
+
+    it("should return questions for specific categories (e.g., 'paises' and 'cine')", async () => {
+      const response = await request(server).get(
+        "/questions?topic=paises,cine&n=5"
+      );
+      expect(response.status).toBe(200);
+      expect(response.body).toBeInstanceOf(Array);
+      expect(response.body.length).toBe(5);
+      response.body.forEach((question) => {
+        expect(question).toHaveProperty("pregunta");
+        expect(question).toHaveProperty("respuestaCorrecta");
+        expect(question).toHaveProperty("respuestas");
+      });
+    }, 30000);
+  });
+
+  describe("Class Question", () => {
+    it("should create a Question instance with correct properties", () => {
+      const respuestaCorrecta = { es: "Respuesta correcta" };
+      const preguntas = { es: "¿Cuál es la capital de Francia?" };
+      const respuestasIncorrectas = { es: ["Madrid", "Roma", "Londres"] };
+      const descripcion = [{ propiedad: "Capital", valor: "París" }];
+      const img = ["img1.jpg"];
+
+      const question = new Question(
+        respuestaCorrecta,
+        preguntas,
+        respuestasIncorrectas,
+        descripcion,
+        img
+      );
+
+      expect(question.respuestaCorrecta).toEqual(respuestaCorrecta);
+      expect(question.preguntas).toEqual(preguntas);
+      expect(question.respuestasIncorrectas).toEqual(respuestasIncorrectas);
+      expect(question.descripcion).toEqual(descripcion);
+      expect(question.img).toEqual(img);
+    });
+
+    it("should return correct question for the specified language", () => {
+      const respuestaCorrecta = { es: "Respuesta correcta" };
+      const preguntas = { es: "¿Cuál es la capital de Francia?" };
+      const respuestasIncorrectas = { es: ["Madrid", "Roma", "Londres"] };
+      const descripcion = [{ propiedad: "Capital", valor: "París" }];
+      const img = ["img1.jpg"];
+
+      const question = new Question(
+        respuestaCorrecta,
+        preguntas,
+        respuestasIncorrectas,
+        descripcion,
+        img
+      );
+      const questionText = question.obtenerPreguntaPorIdioma();
+
+      expect(questionText["es"]).toBe("¿Cuál es la capital de Francia?");
+    });
+
+    it("should return answers in random order", () => {
+      const respuestaCorrecta = { es: "Respuesta correcta" };
+      const preguntas = { es: "¿Cuál es la capital de Francia?" };
+      const respuestasIncorrectas = { es: ["Madrid", "Roma", "Londres"] };
+      const descripcion = [{ propiedad: "Capital", valor: "París" }];
+      const img = ["img1.jpg"];
+
+      const question = new Question(
+        respuestaCorrecta,
+        preguntas,
+        respuestasIncorrectas,
+        descripcion,
+        img
+      );
+      const respuestas = question.obtenerRespuestas()["es"];
+      const original = ["Respuesta correcta", "Madrid", "Roma", "Londres"];
+
+      const cmp = (a, b) =>
+        a.localeCompare(b, "es", { sensitivity: "variant" });
+      expect(respuestas.sort(cmp)).toEqual(original.sort(cmp));
+    });
+
+    it("should return the image associated with the question", () => {
+      const respuestaCorrecta = { es: "Respuesta correcta" };
+      const preguntas = { es: "¿Cuál es la capital de Francia?" };
+      const respuestasIncorrectas = { es: ["Madrid", "Roma", "Londres"] };
+      const descripcion = [{ propiedad: "Capital", valor: "París" }];
+      const img = ["img1.jpg"];
+
+      const question = new Question(
+        respuestaCorrecta,
+        preguntas,
+        respuestasIncorrectas,
+        descripcion,
+        img
+      );
+
+      const imgResult = question.obtenerImg();
+      expect(imgResult).toEqual(img);
+    });
+
+    it("should return the question details as a string", () => {
+      const respuestaCorrecta = { es: "Respuesta correcta" };
+      const preguntas = { es: "¿Cuál es la capital de Francia?" };
+      const respuestasIncorrectas = { es: ["Madrid", "Roma", "Londres"] };
+      const descripcion = [{ propiedad: "Capital", valor: "París" }];
+      const img = ["img1.jpg"];
+
+      const question = new Question(
+        respuestaCorrecta,
+        preguntas,
+        respuestasIncorrectas,
+        descripcion,
+        img
+      );
+      const questionString = question.toString();
+
+      expect(questionString).toContain("🌍 **Idioma:** ES");
+      expect(questionString).toContain(
+        "❓ Pregunta: ¿Cuál es la capital de Francia?"
+      );
+      expect(questionString).toContain(
+        "✅ Respuesta correcta: Respuesta correcta"
+      );
+      expect(questionString).toContain(
+        "❌ Respuestas incorrectas: Madrid, Roma, Londres"
+      );
+      expect(questionString).toContain("📝 **Descripción:** Capital: París");
+      expect(questionString).toContain("📸 **Imagen:** img1.jpg");
+    });
+
+    it("should handle empty descriptions and images", () => {
+      const respuestaCorrecta = { es: "Respuesta correcta" };
+      const preguntas = { es: "¿Cuál es la capital de Francia?" };
+      const respuestasIncorrectas = { es: ["Madrid", "Roma", "Londres"] };
+      const descripcion = [];
+      const img = [];
+
+      const question = new Question(
+        respuestaCorrecta,
+        preguntas,
+        respuestasIncorrectas,
+        descripcion,
+        img
+      );
+      const questionString = question.toString();
+
+      expect(questionString).toContain(
+        "📝 **Descripción:** No hay descripción disponible."
+      );
+      expect(questionString).toContain(
+        "📸 **Imagen:** No hay imagen disponible."
+      );
+    });
+
+    it("should handle missing languages gracefully", () => {
+      const respuestaCorrecta = { es: "Respuesta correcta" };
+      const preguntas = { es: "¿Cuál es la capital de Francia?" };
+      const respuestasIncorrectas = { es: ["Madrid", "Roma", "Londres"] };
+      const descripcion = [{ propiedad: "Capital", valor: "París" }];
+      const img = ["img1.jpg"];
+
+      const question = new Question(
+        respuestaCorrecta,
+        preguntas,
+        respuestasIncorrectas,
+        descripcion,
+        img
+      );
+
+      const questionTextInEnglish = question.obtenerPreguntaPorIdioma()["en"];
+      expect(questionTextInEnglish).toBeUndefined();
+    });
+
+    it("should handle multiple languages correctly", () => {
+      const respuestaCorrecta = {
+        es: "Respuesta correcta",
+        en: "Correct answer",
+      };
+      const preguntas = {
+        es: "¿Cuál es la capital de Francia?",
+        en: "What is the capital of France?",
+      };
+      const respuestasIncorrectas = {
+        es: ["Madrid", "Roma", "Londres"],
+        en: ["Madrid", "Rome", "London"],
+      };
+      const descripcion = [{ propiedad: "Capital", valor: "París" }];
+      const img = ["img1.jpg"];
+
+      const question = new Question(
+        respuestaCorrecta,
+        preguntas,
+        respuestasIncorrectas,
+        descripcion,
+        img
+      );
+
+      const questionTextEs = question.obtenerPreguntaPorIdioma()["es"];
+      const questionTextEn = question.obtenerPreguntaPorIdioma()["en"];
+
+      expect(questionTextEs).toBe("¿Cuál es la capital de Francia?");
+      expect(questionTextEn).toBe("What is the capital of France?");
+    });
+
+    it("should handle empty question and answer arrays", () => {
+      const respuestaCorrecta = { es: "", en: "" };
+      const preguntas = { es: "", en: "" };
+      const respuestasIncorrectas = { es: [], en: [] };
+      const descripcion = [];
+      const img = [];
+
+      const question = new Question(
+        respuestaCorrecta,
+        preguntas,
+        respuestasIncorrectas,
+        descripcion,
+        img
+      );
+
+      const questionTextEs = question.obtenerPreguntaPorIdioma()["es"];
+      const questionTextEn = question.obtenerPreguntaPorIdioma()["en"];
+
+      expect(questionTextEs).toBe("");
+      expect(questionTextEn).toBe("");
+    });
+  });
 });


### PR DESCRIPTION
# Cambios realizados
- Arreglado cuello de botella que impedía el paso de varias peticiones simultáneas a la BD para las preguntas. Arreglados tests también en consecuencia.
- Tests de carga preparados para su documentación.